### PR TITLE
[Setup] Update team metrics configuration file

### DIFF
--- a/gh_metrics_config.json
+++ b/gh_metrics_config.json
@@ -20,7 +20,7 @@
     }
   },
   "lectureTopicTaskQuota": 4,
-  "countOpenIssues": true,
+  "countOpenIssues": false,
   "sprints": 2,
   "minTasksPerSprint": 1
 }


### PR DESCRIPTION
Summary:
- Updated to not count open issues.

Changes:
- 'countOpenIssues': true -> false

Why:
- Counting open issues makes the metrics confusing regarding completed tasks per sprint.
- Example: issues count for sprint 2 may show 2/1 when in reality no task has been closed (0/1).